### PR TITLE
Fix declaration match. 

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -68,7 +68,7 @@ function postConnect() { $this->Lexer->addExitPattern('</showif>','plugin_showif
 /**
  * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
 
 
         switch ($state) {
@@ -87,7 +87,7 @@ function postConnect() { $this->Lexer->addExitPattern('</showif>','plugin_showif
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         global $INFO;
         
         if($mode == 'xhtml'){


### PR DESCRIPTION
Fixes this problem wich occured with PHP7, Dokuwiki version Release rc-2020-06-09 "Hogfather" RC3:
PHP Fatal error:  Declaration of syntax_plugin_showif::handle($match, $state, $pos, &$handler) must be compatible with dokuwiki\\Extension\\SyntaxPlugin::handle($match, $state, $pos, Doku_Handler $handler) in DOKUWIKI_PATH_HERE/lib/plugins/showif/syntax.php on line 0'